### PR TITLE
adding route to resource id for network adapter

### DIFF
--- a/svc-api/router/router.go
+++ b/svc-api/router/router.go
@@ -312,6 +312,7 @@ func Router() *iris.Application {
 	chassis.Get("/", cha.GetChassisCollection)
 	chassis.Get("/{id}", cha.GetChassis)
 	chassis.Get("/{id}/NetworkAdapters", cha.GetChassisResource)
+	chassis.Get("/{id}/NetworkAdapters/{rid}", cha.GetChassisResource)
 	chassis.Any("/", handle.ChassisMethodNotAllowed)
 	chassis.Any("/{id}", handle.ChassisMethodNotAllowed)
 	chassis.Any("/{id}/NetworkAdapters", handle.ChassisMethodNotAllowed)


### PR DESCRIPTION
route for resource id for a network adapter is added to router.go 