### PR TITLE
Odim 3696: removing iLO reference from 'Code' parameter

### DIFF
--- a/plugin-redfish/rfpresponse/errorResponse.go
+++ b/plugin-redfish/rfpresponse/errorResponse.go
@@ -42,7 +42,7 @@ type MsgExtendedInfo struct {
 func CreateErrorResponse(errs string) ErrorResopnse {
 	var err = ErrorResopnse{
 		Error{
-			Code:    "iLO.0.10.ExtendedInfo",
+			Code:    "Base.1.0.0.Failed",
 			Message: "See @Message.ExtendedInfo for more information.",
 			MessageExtendedInfo: []MsgExtendedInfo{
 				MsgExtendedInfo{

--- a/plugin-redfish/rfpresponse/errorResponse.go
+++ b/plugin-redfish/rfpresponse/errorResponse.go
@@ -16,7 +16,7 @@
 package rfpresponse
 
 import (
-	"github.com/ODIM-Project/ODIM/lib-utilities/response"
+	errorResponse "github.com/ODIM-Project/ODIM/lib-utilities/response"
 	iris "github.com/kataras/iris/v12"
 )
 
@@ -43,11 +43,11 @@ type MsgExtendedInfo struct {
 func CreateErrorResponse(errs string) ErrorResopnse {
 	var err = ErrorResopnse{
 		Error{
-			Code:    response.GeneralError,
+			Code:   errorResponse.GeneralError,
 			Message: "See @Message.ExtendedInfo for more information.",
 			MessageExtendedInfo: []MsgExtendedInfo{
 				MsgExtendedInfo{
-					MessageID: "Base.1.0.Failed",
+					MessageID: "Base.1.6.1.GeneralError",
 					Message:   errs,
 				},
 			},

--- a/plugin-redfish/rfpresponse/errorResponse.go
+++ b/plugin-redfish/rfpresponse/errorResponse.go
@@ -16,6 +16,7 @@
 package rfpresponse
 
 import (
+	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	iris "github.com/kataras/iris/v12"
 )
 
@@ -42,7 +43,7 @@ type MsgExtendedInfo struct {
 func CreateErrorResponse(errs string) ErrorResopnse {
 	var err = ErrorResopnse{
 		Error{
-			Code:    "Base.1.0.0.Failed",
+			Code:    response.GeneralError,
 			Message: "See @Message.ExtendedInfo for more information.",
 			MessageExtendedInfo: []MsgExtendedInfo{
 				MsgExtendedInfo{

--- a/svc-events/events/evtsubscription.go
+++ b/svc-events/events/evtsubscription.go
@@ -1260,7 +1260,7 @@ func createEventSubscriptionResponse() interface{} {
 				MessageID: "Base.1.0.Created",
 			},
 		},
-		Code:    "Base.1.0.0.Created",
+		Code:    errResponse.Created,
 		Message: "See @Message.ExtendedInfo for more information.",
 	}
 }

--- a/svc-events/events/evtsubscription.go
+++ b/svc-events/events/evtsubscription.go
@@ -1260,7 +1260,7 @@ func createEventSubscriptionResponse() interface{} {
 				MessageID: "Base.1.0.Created",
 			},
 		},
-		Code:    "iLO.0.10.ExtendedInfo",
+		Code:    "Base.1.0.0.Created",
 		Message: "See @Message.ExtendedInfo for more information.",
 	}
 }

--- a/svc-events/events/evtsubscription.go
+++ b/svc-events/events/evtsubscription.go
@@ -1257,7 +1257,7 @@ func createEventSubscriptionResponse() interface{} {
 	return errors.ErrorClass{
 		MessageExtendedInfo: []errors.MsgExtendedInfo{
 			errors.MsgExtendedInfo{
-				MessageID: "Base.1.0.Created",
+				MessageID: "Base.1.6.1.Created",
 			},
 		},
 		Code:    errResponse.Created,


### PR DESCRIPTION
There are 2 iLO references in 'Code' parameter of error response, which are replaced with message id as per schema 
